### PR TITLE
feat: add ticket restaurant bar

### DIFF
--- a/src/Gtfo.jsx
+++ b/src/Gtfo.jsx
@@ -1,5 +1,10 @@
 import React, { useEffect, useState } from 'react'
-import { getDayProgress, getWeekProgress, getMoneyProgress } from './fn'
+import {
+  getDayProgress,
+  getWeekProgress,
+  getMoneyProgress,
+  getMagicProgress,
+} from './fn'
 import Progress from './Progress'
 
 const styles = {
@@ -34,6 +39,9 @@ const Gtfo = () => {
   const [dayPercent, setDayPercent] = useState(() => getDayProgress())
   const [weekPercent, setWeekPercent] = useState(() => getWeekProgress())
   const [[next15, last15], setMoneyPercent] = useState(() => getMoneyProgress())
+  const [[nextMagic, lastMagic], setMagicRechargePercent] = useState(() =>
+    getMagicProgress(),
+  )
 
   useEffect(() => {
     const dayTimer = setInterval(() => setDayPercent(getDayProgress()), 1000)
@@ -45,11 +53,16 @@ const Gtfo = () => {
       () => setMoneyPercent(getMoneyProgress()),
       60000,
     )
+    const magicTimer = setInterval(
+      () => setMagicRechargePercent(getMagicProgress()),
+      60000,
+    )
 
     return () => {
       clearInterval(dayTimer)
       clearInterval(weekTimer)
       clearInterval(moneyTimer)
+      clearInterval(magicTimer)
     }
   }, [])
 
@@ -86,6 +99,16 @@ const Gtfo = () => {
           to={next15}
           underMsg="pauper's lament... 📉"
           overMsg="gimme money ! 📈"
+        />
+      </div>
+
+      <div className={styles.container}>
+        <Progress
+          label="🌯🥐🥓"
+          from={lastMagic}
+          to={nextMagic}
+          underMsg=""
+          overMsg="burn that card 🔥"
         />
       </div>
     </section>

--- a/src/fn.js
+++ b/src/fn.js
@@ -62,4 +62,27 @@ export const getMoneyProgress = () => {
   return [current, prev]
 }
 
+const magicMonths = [1, 4, 7, 10]
+export const getMagicProgress = () => {
+  const now = londonNow()
+  let nowAltered
+  const nextMonth = magicMonths.find((m) => now.month <= m)
+  if (nextMonth == null) {
+    nowAltered = now
+      .plus({ year: 1 })
+      .set({ month: magicMonths[0], day: DOLLAR })
+  } else {
+    nowAltered = now.set({ month: nextMonth, day: DOLLAR })
+  }
+  const current = getPayDayForMonth(nowAltered)
+
+  if (now.month === current.month && now.day > current.day + 2) {
+    const next = getPayDayForMonth(nowAltered.plus({ months: 3 }))
+    return [next, current.plus({ day: 3 })]
+  }
+
+  const prev = getPayDayForMonth(nowAltered.minus({ month: 3 }))
+  return [current, prev]
+}
+
 export const getProgressCSS = (percent) => `${clamp(100 - percent, 0, 100)}%`


### PR DESCRIPTION
Added a new progress bar for ticket restaurant recharges. The recharge is done each 3 months the same day or the following next days to the pay day. The progress bar stays for 3 days as complete to ensure all users notice that soon will receive their money.